### PR TITLE
Set source prefix to SOURCE if available.

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func init() {
+	Source = ""
 	DefaultDrain.(*LogDrain).DrainFunc = func(s string) {
 		fmt.Println(s)
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -15,12 +15,21 @@ var (
 	DefaultDrain = Drainer(&LogDrain{})
 
 	// Source is the root source that these metrics are coming from.
-	Source = os.Getenv("DYNO")
+	Source string
 
 	// DefaultNamespace is the default namespace to output metrics. By default,
 	// no namespace.
 	DefaultNamespace Namespace
 )
+
+func init() {
+	hostname, _ := os.Hostname()
+	prefix := os.Getenv("SOURCE")
+	if prefix == "" {
+		prefix = os.Getenv("DYNO")
+	}
+	Source = fmt.Sprintf("%s.%s", prefix, hostname)
+}
 
 // NewMetric returns a new Metric.
 func (n Namespace) NewMetric(t, name string, v interface{}, units string) Metric {


### PR DESCRIPTION
Pulling this out of https://github.com/remind101/r101-shorty/pull/40. I suffix the hostname so that sources with the same name, but on different hosts, don't get aggregated as the same source in Librato.