### PR TITLE
Statsd drain

### DIFF
--- a/drain.go
+++ b/drain.go
@@ -1,14 +1,19 @@
 package metrics
 
 import (
+	"bytes"
+	"errors"
 	"log"
+	"math"
 	"os"
+	"text/template"
 )
 
 // Ensure implementations implement the Drainer interface.
 var (
 	_ Drainer = &LogDrain{}
 	_ Drainer = &NullDrain{}
+	_ Drainer = &StatsdDrain{}
 )
 
 // Drainer is an interface that can drain a metric to it's output.
@@ -89,4 +94,91 @@ func (d *LocalStoreDrain) Drain(m Metric) error {
 	}
 	d.Store()[m.Name()] = append(metrics, m)
 	return nil
+}
+
+var ValueInvalidErr = errors.New("value must be one of [int, uint, int32, uint32, int64, uint64]")
+var ValueOverflowErr = errors.New("value for uint64 too large to be converted to int64")
+var InvalidMetricTypeErr = errors.New("metric type must be one of [count, sample, measure]")
+
+type StatsdClient interface {
+	Incr(name string, count int64) error
+	Gauge(name string, value int64) error
+	Timing(name string, ms int64) error
+}
+
+// StatsdDrain is a Drainer that records metrics to a statsd server.
+type StatsdDrain struct {
+	client   StatsdClient
+	template *template.Template
+}
+
+// NewStatsdDrain takes a statsd client and a template string. The template
+// string is used to construct the metric name with a Metric as its context.
+func NewStatsdDrain(c StatsdClient, tmpl string) (*StatsdDrain, error) {
+	t, err := template.New("stat").Parse(tmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StatsdDrain{client: c, template: t}, nil
+}
+
+// Drain records metrics to a statsd server.
+func (d *StatsdDrain) Drain(m Metric) error {
+	name, err := d.name(m)
+	if err != nil {
+		return err
+	}
+
+	value, err := vtoi(m.Value())
+	if err != nil {
+		return err
+	}
+
+	switch m.Type() {
+	case "count":
+		return d.client.Incr(name, value)
+	case "sample", "measure":
+		if m.Units() == "ms" {
+			return d.client.Timing(name, value)
+		} else {
+			return d.client.Gauge(name, value)
+		}
+	default:
+		return InvalidMetricTypeErr
+	}
+}
+
+// name constructs a metric name with the StatsdDrain template.
+func (d *StatsdDrain) name(m Metric) (string, error) {
+	b := new(bytes.Buffer)
+	if err := d.template.Execute(b, m); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// value coerces an interface value to an int64.
+// The metric value MUST be an int or int64 or an error will be returned.
+func vtoi(v interface{}) (int64, error) {
+	switch i := v.(type) {
+	case int:
+		return int64(i), nil
+	case uint:
+		return int64(i), nil
+	case int32:
+		return int64(i), nil
+	case uint32:
+		return int64(i), nil
+	case int64:
+		return i, nil
+	case uint64:
+		if i <= math.MaxInt64 {
+			return int64(i), nil
+		} else {
+			return 0, ValueOverflowErr
+		}
+	default:
+		return 0, ValueInvalidErr
+	}
 }

--- a/drain.go
+++ b/drain.go
@@ -96,9 +96,11 @@ func (d *LocalStoreDrain) Drain(m Metric) error {
 	return nil
 }
 
-var ValueInvalidErr = errors.New("value must be one of [int, uint, int32, uint32, int64, uint64]")
-var ValueOverflowErr = errors.New("value for uint64 too large to be converted to int64")
-var InvalidMetricTypeErr = errors.New("metric type must be one of [count, sample, measure]")
+var (
+	ValueInvalidErr      = errors.New("value must be one of [int, uint, int32, uint32, int64, uint64]")
+	ValueOverflowErr     = errors.New("value for uint64 too large to be converted to int64")
+	InvalidMetricTypeErr = errors.New("metric type must be one of [count, sample, measure]")
+)
 
 type StatsdClient interface {
 	Incr(name string, count int64) error

--- a/drain.go
+++ b/drain.go
@@ -149,10 +149,24 @@ func (d *StatsdDrain) Drain(m Metric) error {
 	}
 }
 
+// templateData is used to render metric names from the StatsdDrain template.
+type templateData struct {
+	Name   string
+	Type   string
+	Units  string
+	Source string
+}
+
 // name constructs a metric name with the StatsdDrain template.
 func (d *StatsdDrain) name(m Metric) (string, error) {
 	b := new(bytes.Buffer)
-	if err := d.template.Execute(b, m); err != nil {
+	data := templateData{
+		Name:   m.Name(),
+		Type:   m.Type(),
+		Units:  m.Units(),
+		Source: Source,
+	}
+	if err := d.template.Execute(b, data); err != nil {
 		return "", err
 	}
 	return b.String(), nil

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,8 +1,10 @@
 package metrics_test
 
 import (
-	metrics "."
+	"errors"
 	"testing"
+
+	metrics "."
 )
 
 func setMetricsDrain(d metrics.Drainer) func() {
@@ -84,4 +86,74 @@ func TestLocalStoreDrainFlush(t *testing.T) {
 		t.Error("Error flushing LocalStoreDrain")
 	}
 
+}
+
+var UnexpectedFuncCall = errors.New("unexpected function call")
+
+type stub func(string, int64) error
+
+var expect = func(t *testing.T, en string, ev int64) stub {
+	return func(n string, v int64) error {
+		if got, want := n, en; got != want {
+			t.Errorf("metric name: expected %q; got %q", got, want)
+		}
+		if got, want := v, ev; got != want {
+			t.Errorf("metric value: expected %q; got %q", got, want)
+		}
+		return nil
+	}
+}
+
+type MockStatsdClient struct {
+	IncrFunc   stub
+	GaugeFunc  stub
+	TimingFunc stub
+}
+
+func (c *MockStatsdClient) Incr(n string, v int64) error {
+	if c.IncrFunc != nil {
+		return c.IncrFunc(n, v)
+	} else {
+		return UnexpectedFuncCall
+	}
+}
+
+func (c *MockStatsdClient) Gauge(n string, v int64) error {
+	if c.GaugeFunc != nil {
+		return c.GaugeFunc(n, v)
+	} else {
+		return UnexpectedFuncCall
+	}
+}
+
+func (c *MockStatsdClient) Timing(n string, v int64) error {
+	if c.TimingFunc != nil {
+		return c.TimingFunc(n, v)
+	} else {
+		return UnexpectedFuncCall
+	}
+}
+
+func TestStatsdDrain(t *testing.T) {
+	mc := &MockStatsdClient{}
+
+	d, err := metrics.NewStatsdDrain(mc, "{{.Name}}.source__test__")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup := setMetricsDrain(d)
+	defer cleanup()
+
+	mc.IncrFunc = expect(t, "requests.count.source__test__", 5)
+	metrics.Count("requests.count", 5)
+
+	mc.GaugeFunc = expect(t, "requests.sample.source__test__", 50)
+	metrics.Sample("requests.sample", 50, "")
+
+	mc.GaugeFunc = expect(t, "requests.measure.source__test__", 500)
+	metrics.Measure("requests.measure", 500, "")
+
+	mc.TimingFunc = expect(t, "requests.timing.source__test__", 5000)
+	metrics.Measure("requests.timing", 5000, "ms")
 }


### PR DESCRIPTION
This adds a StatsdDrain:

``` go
import (
    "github.com/quipo/statsd"
    "github.com/remind101/metrics"
)

func main() {
    c := statsd.NewStatsdClient("localhost:8125", "")
    c.CreateSocket()
    defer c.Close()
    d, err := metrics.NewStatsdDrain(c, "{{.Name}}.source__{{.Source}}__")
    metrics.DefaultDrain = d
}
```

Note only int or int64 values are supported. I think almost everything we currently emit is an int64 or uint64 for the runtime metrics (hopefully they don't actually overflow an int64)