### PR TITLE
Allow float64 values and convert them to int64

### DIFF
--- a/drain.go
+++ b/drain.go
@@ -194,6 +194,8 @@ func vtoi(v interface{}) (int64, error) {
 		} else {
 			return 0, ValueOverflowErr
 		}
+	case float64:
+		return int64(math.Ceil(i)), nil
 	default:
 		return 0, ValueInvalidErr
 	}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -172,7 +172,12 @@ func TestStatsdDrain(t *testing.T) {
 	}
 
 	mc.TimingFunc = expect(t, "requests.timing.source__test__", 5000)
-	if err := metrics.Measure("requests.timing", 500, "ms"); err != nil {
+	if err := metrics.Measure("requests.timing", 5000, "ms"); err != nil {
+		t.Error(err)
+	}
+
+	mc.TimingFunc = expect(t, "requests.timing.source__test__", 101)
+	if err := metrics.Measure("requests.timing", 100.925, "ms"); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
This pretty much assumes that the float64 is a time value
in milliseconds. Its a hack to get metric values flowing again,
real fix will be to update the interface to metrics to use
static types as values.
